### PR TITLE
feature/yth/page-calendar : 캘린더 상세 페이지 피드 조회 기능 구현

### DIFF
--- a/src/components/main/MainFeed.tsx
+++ b/src/components/main/MainFeed.tsx
@@ -19,8 +19,7 @@ const MainFeed = ({ nowData }: { nowData: string }) => {
   }
 
   return (
-    <section className="relative z-0 mt-[1.5rem] flex h-[calc(100%-24.8rem)] flex-col gap-[1.5rem] overflow-auto rounded-t-[3rem] bg-gray-100 p-[1.5rem] shadow-feed scrollbar-hide">
-      <div className="absolute left-1/2 top-0 z-[-1] h-full w-[.1rem] bg-gray-300" />
+    <section className="relative z-0 mt-[1.5rem] flex h-[calc(100%-24.8rem)] flex-col gap-[1.5rem] overflow-auto rounded-t-[3rem] bg-gray-100 bg-[linear-gradient(to_right,_transparent,_transparent_50%,_#E2E2E2_50%,_#E2E2E2_50.3%,_transparent_50.3%)] bg-[length:100%_1px] bg-center p-[1.5rem] shadow-feed scrollbar-hide">
       {isLoading ? (
         <>로딩 중...</>
       ) : (

--- a/src/types/UserType.ts
+++ b/src/types/UserType.ts
@@ -1,19 +1,35 @@
 import { z } from "zod";
 
 export const AuthorSchema = z.object({
-  user_id: z.number().int(),
-  name: z.string(),
+  userId: z.number().int(),
+  nickname: z.string(),
   birth: z.string().optional(),
   balance: z.number().default(0).optional(),
-  couple_user_id: z.number().int().optional(),
-  profileImage: z.string().optional(),
+  coupleBalance: z.number().default(0).optional(),
+  coupleUserId: z.number().int().optional(),
+  profilePictureUrl: z.string().optional(),
 });
 
 export const UserSchema = z.object({
-  author: AuthorSchema,
+  userId: z.number().int(),
+  nickname: z.string().max(12),
+  birth: z.string().optional(),
+  balance: z.number().default(0).optional(),
+  coupleBalance: z.number().default(0).optional(),
+  coupleUserId: z.number().int().optional(),
+  profilePictureUrl: z.string().optional(),
+  email: z.string().email("올바른 이메일 형식이 아닙니다"),
+  region: z.string(),
+});
+
+export const PatchUserSchema = z.object({
+  nickname: z.string().max(12),
+  birth: z.string().optional(),
+  profilePictureUrl: z.string().optional(),
   email: z.string().email("올바른 이메일 형식이 아닙니다"),
   region: z.string(),
 });
 
 export type UserProfileType = z.infer<typeof AuthorSchema>;
 export type UserType = z.infer<typeof UserSchema>;
+export type PatchUserType = z.infer<typeof PatchUserSchema>;


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [x] 기능 추가 : 캘린더 상세 페이지 피드 조회 기능 구현
- [ ] 마크업 & 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

- 캘린더 상세 페이지 피드 조회 기능 구현

<br>

## 🌟 전달 사항

- 캘린더 페이지에서 유저 가입 날짜에 따른 캘린더 생성 부분 남았습니다.

<br>

## ⚠️ Issue Number

- #28 

<br><br>
