### PR TITLE
feature/yth/toast : Toast UI 생성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "clsx": "^2.1.1",
         "dayjs": "^1.11.13",
         "embla-carousel-react": "^8.3.0",
+        "lucide-react": "^0.460.0",
         "path": "^0.12.7",
         "react": "^18.3.1",
         "react-device-detect": "^2.2.3",
@@ -3901,6 +3902,14 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "node_modules/lucide-react": {
+      "version": "0.460.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.460.0.tgz",
+      "integrity": "sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "clsx": "^2.1.1",
     "dayjs": "^1.11.13",
     "embla-carousel-react": "^8.3.0",
+    "lucide-react": "^0.460.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-device-detect": "^2.2.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import axios from "axios";
 import { isMobile } from "react-device-detect";
 import Navbar from "./components/layout/Nav";
 import { cn } from "./utils";
+import { ToastProvider, useToastContext } from "./libs/custom-toast";
 import { IconLogoDoubloom } from "@/assets/icon";
 
 const queryClient = new QueryClient();
@@ -13,6 +14,8 @@ axios.defaults.withCredentials = true;
 // axios.defaults.baseURL = import.meta.env.VITE_APP_API_ENDPOINT;
 
 function App() {
+  useToastContext(); // context 설정을 위해 추가
+
   return (
     <QueryClientProvider client={queryClient}>
       <div className={`flex h-dvh items-center justify-center bg-[#fff5f5]`}>
@@ -32,14 +35,16 @@ function App() {
           </div>
           {/* Right section - 앱 영역 */}
           <div className="right-section relative flex w-full justify-center lg:w-[37.5rem] lg:min-w-[37.5rem]">
-            <div className={cn("h-dvh w-full bg-white shadow-lg", isMobile ? "w-full" : "max-w-[37.5rem]")}>
-              <div className="flex h-full flex-col">
-                <div className="flex-1 overflow-y-auto pb-[6.5rem] will-change-scroll">
-                  <Outlet />
+            <ToastProvider autoClose={1000} limit={3}>
+              <div className={cn("h-dvh w-full bg-white shadow-lg", isMobile ? "w-full" : "max-w-[37.5rem]")}>
+                <div className="flex h-full flex-col">
+                  <div className="flex-1 overflow-y-auto pb-[6.5rem] will-change-scroll">
+                    <Outlet />
+                  </div>
+                  <Navbar />
                 </div>
-                <Navbar />
               </div>
-            </div>
+            </ToastProvider>
           </div>
         </div>
       </div>

--- a/src/libs/custom-toast.tsx
+++ b/src/libs/custom-toast.tsx
@@ -1,0 +1,195 @@
+import React, { useState, useEffect, createContext, useContext, ReactNode } from "react";
+// import { CheckCircle, AlertTriangle, AlertCircle } from "lucide-react";
+
+type ToastType = "success" | "error" | "warn" | "info";
+
+interface Toast {
+  id: string;
+  message: string;
+  type: ToastType;
+  duration: number;
+}
+
+interface ToastContextType {
+  toasts: Toast[];
+  toast: {
+    success: (message: string, duration?: number) => void;
+    error: (message: string, duration?: number) => void;
+    warn: (message: string, duration?: number) => void;
+    info: (message: string, duration?: number) => void;
+  };
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+export const ToastProvider: React.FC<{
+  children: ReactNode;
+  autoClose?: number;
+  limit?: number;
+}> = ({ children, autoClose = 3000, limit = 3 }) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const removeToast = (id: string) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  };
+
+  const addToast = (message: string, type: ToastType, duration?: number) => {
+    const id = Math.random().toString(36).substr(2, 9);
+    const newToast: Toast = {
+      id,
+      message,
+      type,
+      duration: duration || autoClose,
+    };
+
+    setToasts((prev) => (limit ? prev.slice(-(limit - 1)).concat(newToast) : prev.concat(newToast)));
+
+    setTimeout(() => removeToast(id), newToast.duration);
+  };
+
+  const toastMethods = {
+    success: (message: string, duration?: number) => addToast(message, "success", duration),
+    error: (message: string, duration?: number) => addToast(message, "error", duration),
+    warn: (message: string, duration?: number) => addToast(message, "warn", duration),
+    info: (message: string, duration?: number) => addToast(message, "info", duration),
+  };
+
+  return (
+    <ToastContext.Provider value={{ toasts, toast: toastMethods }}>
+      {children}
+      <ToastContainer />
+    </ToastContext.Provider>
+  );
+};
+
+const toastStyles = {
+  success: "bg-green-500 text-white",
+  error: "bg-red-500 text-white",
+  warn: "bg-yellow-500 text-black",
+  info: "bg-black text-red",
+};
+
+// const toastIcons = {
+//   success: CheckCircle,
+//   error: AlertCircle,
+//   warn: AlertTriangle,
+//   info: AlertCircle,
+// };
+
+export const ToastContainer: React.FC = () => {
+  const context = useContext(ToastContext);
+  if (!context) return null;
+
+  const { toasts } = context; // `removeToast`는 특정 toast를 제거하는 함수라고 가정
+
+  const [exitingToasts, setExitingToasts] = useState<Set<string>>(new Set());
+
+  const handleAnimationEnd = (toastId: string) => {
+    if (exitingToasts.has(toastId)) {
+      setExitingToasts((prev) => {
+        const updated = new Set(prev);
+        updated.delete(toastId);
+        return updated;
+      });
+    }
+  };
+
+  const handleRemove = (toastId: string) => {
+    setExitingToasts((prev) => new Set(prev).add(toastId));
+  };
+
+  useEffect(() => {
+    const timers = toasts.map((toast) => setTimeout(() => handleRemove(toast.id), toast.duration || 3000));
+    return () => timers.forEach(clearTimeout);
+  }, [toasts]);
+
+  return (
+    <div className="pointer-events-none absolute top-[1.5rem] z-[9999] flex items-center justify-center">
+      <div className="space-y-2">
+        {toasts.map((toast) => {
+          // const Icon = toastIcons[toast.type];
+          const isExiting = exitingToasts.has(toast.id);
+
+          return (
+            <div
+              key={toast.id}
+              className={`flex h-[5rem] w-[34.5rem] items-center justify-center rounded-[1rem] p-3 opacity-[0.9] transition-all ${
+                toastStyles[toast.type]
+              } ${isExiting ? "animate-fadeout" : "animate-fadein"}`}
+              onAnimationEnd={() => handleAnimationEnd(toast.id)}
+            >
+              {/* <Icon className="mr-2" size={20} /> */}
+              <span className="text-[1.4rem] font-extrabold leading-normal">{toast.message}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context.toast;
+};
+
+// 전역 toast 객체를 위한 별도의 관리 로직
+class ToastManager {
+  private static instance: ToastManager;
+  private toastContext: ToastContextType | null = null;
+
+  private constructor() {}
+
+  static getInstance() {
+    if (!ToastManager.instance) {
+      ToastManager.instance = new ToastManager();
+    }
+    return ToastManager.instance;
+  }
+
+  setContext(context: ToastContextType) {
+    this.toastContext = context;
+  }
+
+  success(message: string, duration?: number) {
+    if (this.toastContext) {
+      this.toastContext.toast.success(message, duration);
+    }
+  }
+
+  error(message: string, duration?: number) {
+    if (this.toastContext) {
+      this.toastContext.toast.error(message, duration);
+    }
+  }
+
+  warn(message: string, duration?: number) {
+    if (this.toastContext) {
+      this.toastContext.toast.warn(message, duration);
+    }
+  }
+
+  info(message: string, duration?: number) {
+    if (this.toastContext) {
+      this.toastContext.toast.info(message, duration);
+    }
+  }
+}
+
+export const toast = ToastManager.getInstance();
+
+// ToastProvider에서 context를 설정하는 훅
+export const useToastContext = () => {
+  const context = useContext(ToastContext);
+
+  useEffect(() => {
+    if (context) {
+      toast.setContext(context);
+    }
+  }, [context]);
+
+  return context;
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -68,6 +68,21 @@ const config: Config = {
       },
 
       scrollbar: ["hidden"], //스크롤바 숨기기
+
+      keyframes: {
+        fadein: {
+          "0%": { opacity: "0", transform: "translateY(-10px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
+        },
+        fadeout: {
+          "0%": { opacity: "1", transform: "translateY(0)" },
+          "100%": { opacity: "0", transform: "translateY(-10px)" },
+        },
+      },
+      animation: {
+        fadein: "fadein 0.5s ease-in-out",
+        fadeout: "fadeout 1s ease-in-out",
+      },
     },
   },
   plugins: [utilsPlugin],


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [x] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [x] 개발 환경 세팅 : lucide-react 라이브러리 설치

<br>

## 💡 상세 작업 내용

![image](https://github.com/user-attachments/assets/80cfe77d-5c4e-43d5-808e-272fe883b0be)

<br>

## 🌟 전달 사항

### 사용 방법

#### 1. 사용하는 부분 Provider로 감싸기
- autoClose는 default 없어지는 시간
- limit은 최대 한 번에 나오는 Toast 갯수
- 현재는 App 컴포넌트 오른쪽 영역에만 적용했습니다.
![image](https://github.com/user-attachments/assets/a4659f4f-042f-4576-a1c5-9882a14e0906)

#### 2. 사용하기
- toast.success("성공~", 10000);
- 첫 번째는 보여질 텍스트, 두 번째는 보여지는 시간 1초에 1000으로 생각하시면 됩니다.
![image](https://github.com/user-attachments/assets/0359bd7f-2c5d-43a4-b28e-bfdc7dbaac3e)


<br>

## ⚠️ Issue Number

- #75 

<br><br>
