### PR TITLE
Hotfix/yth/input-scale-adjustment : input, textarea focus 시 줌인 방지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,7 @@ function App() {
               <div className={cn("h-dvh w-full bg-white shadow-lg", isMobile ? "w-full" : "max-w-[37.5rem]")}>
                 <div className="flex h-full flex-col">
                   <div
-                    className={`flex-1 overflow-y-auto ${pathname.includes("map") || pathname.includes("hospital/") || pathname.includes("policy/") ? "" : "pb-[6.5rem]"} will-change-scroll`}
+                    className={`flex-1 overflow-y-auto overflow-x-hidden ${pathname.includes("map") || pathname.includes("hospital/") || pathname.includes("policy/") ? "" : "pb-[6.5rem]"} will-change-scroll`}
                   >
                     <Outlet />
                   </div>

--- a/src/components/common/CommentInput.tsx
+++ b/src/components/common/CommentInput.tsx
@@ -39,7 +39,7 @@ const CommentInput = ({ type, id }: { type: string; id: string }) => {
 
   return (
     <footer className="h-[8rem] p-[1.5rem]">
-      <Input className="h-[5rem] cursor-text" onSend={onSend} />
+      <Input className="cursor-text" onSend={onSend} />
     </footer>
   );
 };

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -4,8 +4,19 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { Button } from "./Button";
 
+// const inputVariants = cva(
+//   "border-input w-full bg-[#fff] placeholder:text-muted-foreground rounded-[1rem] border border-gray pl-[1.4rem] pr-[7rem] py-[1.2rem] text-[1.4rem] font-medium focus-visible:outline-none disabled:opacity-50 selection:bg-red selection:bg-opacity-70 selection:text-[#fff]",
+//   {
+//     variants: { variant: { default: "text-gray cursor-default", active: "text-black cursor-text" } },
+//     defaultVariants: {
+//       variant: "default",
+//     },
+//   },
+// );
+
+// #91 font 스케일 조정으로 인한 값 수정
 const inputVariants = cva(
-  "border-input w-full bg-[#fff] placeholder:text-muted-foreground rounded-[1rem] border border-gray pl-[1.4rem] pr-[7rem] py-[1.2rem] text-[1.4rem] font-medium focus-visible:outline-none disabled:opacity-50 selection:bg-red selection:bg-opacity-70 selection:text-[#fff]",
+  "border-input w-[114.2857%] h-[57.14285px] bg-[#fff] placeholder:text-muted-foreground rounded-[1.142857rem] border border-gray pl-[1.6rem] pr-[8rem] py-[1.371428rem] text-[1.6rem] font-medium focus-visible:outline-none disabled:opacity-50 selection:bg-red selection:bg-opacity-70 selection:text-[#fff] transform scale-[0.875] origin-top-left",
   {
     variants: { variant: { default: "text-gray cursor-default", active: "text-black cursor-text" } },
     defaultVariants: {
@@ -53,7 +64,14 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           {...props}
         />
         {isButton && (
-          <div className="absolute right-[1.4rem] top-1/2 -translate-y-1/2 transform">
+          // <div className="absolute right-[1.4rem] top-1/2 -translate-y-1/2 transform">
+          //   <Button disabled={!isButtonEnabled} variant="oval" size="sm" onClick={handleSend}>
+          //     완료
+          //   </Button>
+          // </div>
+
+          // font 스케일 조정으로 인한 값 수정
+          <div className="absolute right-[1.4rem] top-[45%] -translate-y-[53%] transform">
             <Button disabled={!isButtonEnabled} variant="oval" size="sm" onClick={handleSend}>
               완료
             </Button>

--- a/src/components/common/form/FormTag.tsx
+++ b/src/components/common/form/FormTag.tsx
@@ -39,11 +39,20 @@ const FormTag = ({ form }: TFormTagProps) => {
   return (
     <div className="flex flex-col gap-[1.4rem] py-[1.5rem]">
       <div className="flex h-[5rem] w-full items-center justify-between rounded-[1rem] border border-gray-300 px-[1.5rem] py-[1rem]">
-        <input
+        {/* <input
           ref={tagInputRef}
           type="text"
           placeholder="태그를 입력해 주세요"
           className="w-[22rem] border-none text-[1.4rem] font-medium outline-none"
+          onKeyUp={handleEnterEvent}
+        /> */}
+
+        {/* #91 font 스케일 조정으로 인한 값 수정 */}
+        <input
+          ref={tagInputRef}
+          type="text"
+          placeholder="태그를 입력해 주세요"
+          className="ml-[-13.42857px] w-[25.142854rem] scale-[0.875] transform border-none text-[1.6rem] font-medium outline-none"
           onKeyUp={handleEnterEvent}
         />
         <div className="flex items-center gap-[1.5rem] text-[1.4rem]">

--- a/src/components/community/CommunityPostForm.tsx
+++ b/src/components/community/CommunityPostForm.tsx
@@ -152,13 +152,23 @@ const CommunityPostForm = ({ id, type, initialData = null, onClose }: TCommunity
         <CommunityFormImage form={form as UseFormReturn<CommunityPostFormType>} />
 
         {/* 텍스트 입력 영역 */}
+        {/* <textarea
+          {...form.register("content", {
+            required: true,
+            validate: (value) => value.trim().length > 0,
+          })}
+          placeholder="내용을 입력해 주세요"
+          className="h-full resize-none text-[1.4rem] font-medium leading-[2rem] tracking-[-0.028rem] text-black outline-none"
+        /> */}
+
+        {/* #91 font 스케일 조정으로 인한 값 수정 */}
         <textarea
           {...form.register("content", {
             required: true,
             validate: (value) => value.trim().length > 0,
           })}
           placeholder="내용을 입력해 주세요"
-          className="h-full resize-none text-[1.4rem] font-medium leading-[2rem] tracking-[-0.028] text-black outline-none"
+          className="w-[114.2857%] origin-top-left scale-[0.875] transform resize-none text-[1.6rem] font-medium leading-[2.2857rem] tracking-[-0.032rem] text-black outline-none"
         />
 
         <FormTag form={form as UseFormReturn<CommunityPostFormType>} />

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/utils";
 import React from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { isMobile } from "react-device-detect";
 import { IconNavHome, IconNavMypage, IconNavPolicy, IconNavHospital, IconNavCommunity } from "@/assets/icon";
 
 type NavItem = {
@@ -23,6 +24,7 @@ const NavBarContainer = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HT
       ref={ref}
       className={cn(
         "fixed bottom-0 flex w-full items-center justify-between border-t border-gray-300 bg-[#fff] px-[3rem] py-[1.2rem] md_mobile:px-[4rem] lg:w-[37.5rem] lg:min-w-[37.5rem]",
+        isMobile ? "w-full" : "max-w-[37.5rem]",
         className,
       )}
       {...props}

--- a/src/components/main/MainBoardForm.tsx
+++ b/src/components/main/MainBoardForm.tsx
@@ -139,13 +139,23 @@ const MainBoardForm = ({ id, type, initialData = null, onClose }: TMainBoardForm
         <BoardFormImage form={form} />
 
         {/* 텍스트 입력 영역 */}
-        <textarea
+        {/* <textarea
           {...form.register("content", {
             required: true,
             validate: (value) => value.trim().length > 0,
           })}
           placeholder="내용을 입력해 주세요"
           className="h-full resize-none text-[1.4rem] font-medium leading-[2rem] tracking-[-0.028] text-black outline-none"
+        /> */}
+
+        {/* #91 font 스케일 조정으로 인한 값 수정 */}
+        <textarea
+          {...form.register("content", {
+            required: true,
+            validate: (value) => value.trim().length > 0,
+          })}
+          placeholder="내용을 입력해 주세요"
+          className="h-full w-[114.2857%] origin-top-left scale-[0.875] transform resize-none text-[1.6rem] font-medium leading-[2.2857rem] tracking-[-0.032rem] text-black outline-none"
         />
       </form>
 

--- a/src/components/main/MainQuestionForm.tsx
+++ b/src/components/main/MainQuestionForm.tsx
@@ -124,11 +124,18 @@ const MainQuestionForm = ({
       <div className="flex h-full flex-col">
         <h1 className="py-[1.5rem] text-[2.4rem] font-bold leading-[3rem] tracking-[-0.048rem] text-black">{qTitle}</h1>
         <hr className="mb-[2rem] mt-[1.5rem]" />
-        <textarea
+        {/* <textarea
           ref={textRef}
           placeholder="답변을 입력해 주세요"
           className="h-full resize-none text-[1.4rem] font-medium leading-[2rem] tracking-[-0.028] text-black outline-none"
-        ></textarea>
+        /> */}
+
+        {/* #91 font 스케일 조정으로 인한 값 수정 */}
+        <textarea
+          ref={textRef}
+          placeholder="답변을 입력해 주세요"
+          className="h-full w-[114.2857%] origin-top-left scale-[0.875] transform resize-none text-[1.6rem] font-medium leading-[2.2857rem] tracking-[-0.032rem] text-black outline-none"
+        />
       </div>
 
       <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 : input, textarea focus 시 줌인 방지 (scale 추가)
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

- input, textarea에서 iOS의 경우 폰트 사이즈가 16px보다 작으면 focus 시 자동으로 줌인 되는 현상 발생
- 폰트 사이즈를 16px로 고정을 하고 줄이고 싶은 사이즈 만큼 scale로 조정

<br>

## 🌟 전달 사항

<br>

## ⚠️ Issue Number

- #91 

<br><br>
